### PR TITLE
Add FastAPI prototype with basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+database.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Access Cloud Prototype
+
+This repository contains a minimal FastAPI-based prototype that demonstrates
+basic CRUD operations for records. It is **not** a full MS Access replacement
+but serves as a starting point for development using TDD.
+
+## Requirements
+
+- Python 3.11+
+- `fastapi`
+- `uvicorn`
+- `sqlmodel`
+- `pytest`
+
+Install dependencies:
+
+```bash
+pip install fastapi uvicorn sqlmodel pytest
+```
+
+## Running the App
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI, HTTPException
+from sqlmodel import Session, select, create_engine
+
+from .models import Record, SQLModel
+
+
+app = FastAPI()
+engine = create_engine("sqlite:///database.db", echo=False)
+
+SQLModel.metadata.create_all(engine)
+
+
+@app.post("/records/", response_model=Record)
+def create_record(record: Record):
+    with Session(engine) as session:
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+        return record
+
+
+@app.get("/records/", response_model=list[Record])
+def read_records():
+    with Session(engine) as session:
+        return session.exec(select(Record)).all()
+
+
+@app.get("/records/{record_id}", response_model=Record)
+def read_record(record_id: int):
+    with Session(engine) as session:
+        record = session.get(Record, record_id)
+        if not record:
+            raise HTTPException(status_code=404, detail="Record not found")
+        return record
+
+
+@app.put("/records/{record_id}", response_model=Record)
+def update_record(record_id: int, item: Record):
+    with Session(engine) as session:
+        db_item = session.get(Record, record_id)
+        if not db_item:
+            raise HTTPException(status_code=404, detail="Record not found")
+        db_item.name = item.name
+        db_item.description = item.description
+        session.add(db_item)
+        session.commit()
+        session.refresh(db_item)
+        return db_item
+
+
+@app.delete("/records/{record_id}")
+def delete_record(record_id: int):
+    with Session(engine) as session:
+        item = session.get(Record, record_id)
+        if not item:
+            raise HTTPException(status_code=404, detail="Record not found")
+        session.delete(item)
+        session.commit()
+        return {"ok": True}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,7 @@
+from sqlmodel import SQLModel, Field
+
+
+class Record(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    description: str | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlmodel
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_record():
+    response = client.post("/records/", json={"name": "Test", "description": "desc"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Test"
+    assert data["description"] == "desc"
+    assert "id" in data
+
+
+def test_read_records():
+    client.post("/records/", json={"name": "Item1"})
+    response = client.get("/records/")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+
+
+def test_update_and_delete_record():
+    resp = client.post("/records/", json={"name": "to_update"})
+    record_id = resp.json()["id"]
+
+    update_resp = client.put(f"/records/{record_id}", json={"name": "updated", "description": "new"})
+    assert update_resp.status_code == 200
+    assert update_resp.json()["name"] == "updated"
+
+    delete_resp = client.delete(f"/records/{record_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["ok"] is True


### PR DESCRIPTION
## Summary
- add a minimal FastAPI prototype under `app/`
- define a `Record` model and CRUD endpoints
- add pytest suite for TDD demonstration
- include setup instructions in README
- ignore database and cache files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac317c1d8832fa4aa403d3e6dcf9d